### PR TITLE
Introduce 'showpasswd' alias

### DIFF
--- a/libexec/bash_login
+++ b/libexec/bash_login
@@ -47,6 +47,11 @@ if [ -f /run/atomic-devmode ]; then
             new-session -s devmode -n main \
                 /usr/libexec/atomic-devmode/init
     fi
+
+    # provide an alias to print the root password to the command line,
+    # in case someone scrolls the top pane too far and doesn't know how
+    # to get back with tmux.
+    alias showpasswd='cat /run/atomic-devmode-root'
 fi
 
 # drop strict mode so that normal shells don't inherit it

--- a/libexec/init
+++ b/libexec/init
@@ -94,9 +94,9 @@ top_pane() {
 	echo "the user \"root\" and the password above."
 	echo
 
-    echo "You can retrieve the password for the \"root\""
-    echo "user at any time with the command \"showpasswd\""
-    echo
+	echo "You can retrieve the password for the \"root\""
+	echo "user at any time with the command \"showpasswd\"."
+	echo
 
 	echo "Use Ctrl+Space to change active pane."
 	echo "Use Alt+1/2/3 to change active window."

--- a/libexec/init
+++ b/libexec/init
@@ -48,7 +48,7 @@ main() {
 	# time to become a shell that the user can type in
 	# NB: turn off (the rest of) strict mode so we act like a normal shell
 	set +uo pipefail
-	exec bash
+	exec bash --login
 }
 
 top_pane() {
@@ -93,6 +93,10 @@ top_pane() {
 	echo "You can now log in the Cockpit console with"
 	echo "the user \"root\" and the password above."
 	echo
+
+    echo "You can retrieve the password for the \"root\""
+    echo "user at any time with the command \"showpasswd\""
+    echo
 
 	echo "Use Ctrl+Space to change active pane."
 	echo "Use Alt+1/2/3 to change active window."


### PR DESCRIPTION
It is possible for a user of devmode to scroll the top pane of the
devmode session so that the root password disappears from the console.
If the user had not recorded the root password or not changed it or
otherwise was incapable of remembering the password, they are left in a
bind.

This change introduces an alias, `showpasswd`, that will print the root
password to the screen again.  Since the root password is automatically
generated and stored in `/run/atomic-devmode-root`, the alias just does
a `cat` on the file.

I also updated `init` to include a message about the `showpasswd`
command.